### PR TITLE
Latin American Spanish translation.

### DIFF
--- a/res/text/bms_page_es-419.txt
+++ b/res/text/bms_page_es-419.txt
@@ -1,4 +1,4 @@
-Modo
+Modo de Juego
 Normal
 Demostración
 Atrás
@@ -7,3 +7,4 @@ Error al leer Be-Music Source
 Debe haber al menos un beatmap osu!/nmania válido en la carpeta. Además, el nombre de la carpeta no debe ser demasiado largo ni contener caracteres especiales.
 Error al leer el fondo de Beatmap
 Error al leer Be-Music Source
+Nivel de dificultad

--- a/res/text/bms_page_es-419.txt
+++ b/res/text/bms_page_es-419.txt
@@ -1,0 +1,9 @@
+Modo
+Normal
+Demostración
+Atrás
+Análisis de beatmaps
+Error al leer Be-Music Source
+Debe haber al menos un beatmap osu!/nmania válido en la carpeta. Además, el nombre de la carpeta no debe ser demasiado largo ni contener caracteres especiales.
+Error al leer el fondo de Beatmap
+Error al leer Be-Music Source

--- a/res/text/common_es-419.txt
+++ b/res/text/common_es-419.txt
@@ -1,0 +1,27 @@
+Atrás
+Seleccionar Beatmaps
+Editar colores
+Comprobar
+Configuración de teclas
+Pausar/Salir
+Columna
+Presione una tecla para
+Cancelar
+No selecciono teclas para este modo
+Registrar.
+RESULTADOS
+cualquier tecla para continuar
+Editar
+Puntaje total
+Combo máximo
+Precisión
+Combos completados
+Guardar y salir
+Seleccionar temas
+Configuración
+Audio
+Sistema
+cancelar
+Continuar
+Reintentar
+Cerrar

--- a/res/text/sets_audio_es-419.txt
+++ b/res/text/sets_audio_es-419.txt
@@ -1,0 +1,5 @@
+Activar sonidos de impacto
+Activar la retroalimentación
+Usar muestras de beatmap
+Velocidad de sonido
+<<< atrás

--- a/res/text/sets_main_es-419.txt
+++ b/res/text/sets_main_es-419.txt
@@ -4,4 +4,5 @@ Configuración del sistema
 Fondo oscuro
 Velocidad de desplazamiento
 Ubicación de la carpeta
+Game language
 <<< atrás

--- a/res/text/sets_main_es-419.txt
+++ b/res/text/sets_main_es-419.txt
@@ -1,0 +1,7 @@
+Componer mezclas
+Configuración del sonido
+Configuración del sistema
+Fondo oscuro
+Velocidad de desplazamiento
+Ubicación de la carpeta
+<<< atrás

--- a/res/text/sets_system_es-419.txt
+++ b/res/text/sets_system_es-419.txt
@@ -1,4 +1,5 @@
 Mostrar interfaz durante el juego
 Mostrar contadores
 Pantalla completa
+Activar perfiles
 <<< atrás

--- a/res/text/sets_system_es-419.txt
+++ b/res/text/sets_system_es-419.txt
@@ -1,0 +1,4 @@
+Mostrar interfaz durante el juego
+Mostrar contadores
+Pantalla completa
+<<< atrás


### PR DESCRIPTION
This translation is made for the Latin America region. Since the meanings of the words can vary with the Spanish (Castillan) of the country of Spain.
es = Spanish
es-419 = Spanish for Latin America and the Caribbean
https://en.wikipedia.org/wiki/Language_code
https://en.wikipedia.org/wiki/UN_M49

Will the translation of the images of the game also take place?

