### PR TITLE
Avoid modifying input state while processing it

### DIFF
--- a/src/nmania/Player.java
+++ b/src/nmania/Player.java
@@ -84,6 +84,7 @@ public final class Player extends GameCanvas {
 		columnsCount = map.columnsCount;
 		columns = new int[columnsCount][];
 		currentNote = new int[columnsCount];
+		tempKeys = new boolean[columnsCount];
 		holdKeys = new boolean[columnsCount];
 		lastHoldKeys = new boolean[columnsCount];
 		int[] kbl = Settings.keyLayout[columnsCount - 1];
@@ -277,8 +278,18 @@ public final class Player extends GameCanvas {
 	private final int columnsCount;
 	private final int[][] columns;
 	private final int[] currentNote;
+	/**
+	 * Copy of {@link #holdKeys}, lags 1 frame behind.
+	 */
 	private final boolean[] lastHoldKeys;
+	/**
+	 * Copy of {@link #tempKeys} to lock input state while working on input frame.
+	 */
 	private final boolean[] holdKeys;
+	/**
+	 * Stores currently holded keys.
+	 */
+	private final boolean[] tempKeys;
 	private final int[] holdHoldingTimes;
 	private final boolean[] holdHeadScored;
 	private final int[] keyMappings;
@@ -493,7 +504,7 @@ public final class Player extends GameCanvas {
 	}
 
 	public final void ToggleColumnInputState(int column, boolean state) {
-		holdKeys[column] = state;
+		tempKeys[column] = state;
 		GL.Log("(input) " + state + " on column " + column + " at time " + time + ", global frame " + framesPassed);
 		if (recorder != null)
 			recorder.Receive(time, column, state);
@@ -529,6 +540,7 @@ public final class Player extends GameCanvas {
 				// replay handling
 				time = input.UpdatePlayer(this, time);
 			}
+			System.arraycopy(tempKeys, 0, holdKeys, 0, columnsCount);
 
 			if (isPaused) {
 				PauseUpdateLoop();


### PR DESCRIPTION
This avoids issues with threads switching causing input state to be changed at unexpected moments.